### PR TITLE
fix: Write results when giving up without a patch

### DIFF
--- a/appmap/solve.py
+++ b/appmap/solve.py
@@ -18,8 +18,6 @@ from appmap.archive import ArchiveFinder
 
 
 def output_results(instance, output_file, patch):
-    if patch is None:
-        return
     instance["model_patch"] = patch
     instance["model_name_or_path"] = "navie"
     with FileLock(f"{output_file}.lock"):
@@ -161,6 +159,7 @@ def worker_init(data: dict):
                                 attempt_number += 1
                                 if attempt_number >= retries:
                                     print(f"Giving up after {attempt_number} attempts")
+                                    output_results(instance, output_file, None)
 
                     except Exception:
                         print(f"Error processing {instance['instance_id']}")


### PR DESCRIPTION
Non-generated patches are now reported

```
$ python appmap/report.py
no_generation: 7
generated: 7
with_logs: 7
install_fail: 0
reset_failed: 0
no_apply: 0
applied: 7
applied_minimal: 0
test_errored: 0
test_timeout: 0
resolved: 3
Wrote 14 predictions to results.csv
```