### PR TITLE
ci: Bring back build cache, but actually working

### DIFF
--- a/.github/workflows/solve.yml
+++ b/.github/workflows/solve.yml
@@ -39,10 +39,25 @@ jobs:
         with:
           submodules: true
 
+      # Cache the appmap-js build
+      - name: Cache appmap-js build
+        uses: actions/cache@v4
+        id: cache-appmap-js
+        with:
+          lookup-only: true
+          path: |
+            submodules/appmap-js/node_modules
+            submodules/appmap-js/packages/*/built
+            submodules/appmap-js/packages/*/dist
+            submodules/appmap-js/packages/*/node_modules
+          key: appmap-js-dist-${{ runner.os }}-${{ hashFiles('.git/modules/submodules/appmap-js/HEAD') }}
+
       - name: Set up Node.js
+        if: steps.cache-appmap-js.outputs.cache-hit != 'true'
         uses: actions/setup-node@v3
 
       - name: Build submodules
+        if: steps.cache-appmap-js.outputs.cache-hit != 'true'
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
         run: |
@@ -91,7 +106,7 @@ jobs:
             submodules/appmap-js/packages/*/built
             submodules/appmap-js/packages/*/dist
             submodules/appmap-js/packages/*/node_modules
-          key: appmap-js-dist-${{ runner.os }}-${{ hashFiles('.git/modules/submodules/appmap-js/refs/heads') }}
+          key: appmap-js-dist-${{ runner.os }}-${{ hashFiles('.git/modules/submodules/appmap-js/HEAD') }}
 
       - name: Run benchmark
         env:


### PR DESCRIPTION
The problem was that it was looking at `.git/modules/submodules/appmap-js/refs/heads` for the cache key, which actually says what's the main branch in appmap-js repo. For the referenced branch, we want to use `.git/modules/submodules/appmap-js/HEAD`
