### PR TITLE
fix: Testbed initialization runs on main thread

### DIFF
--- a/swebench/harness/context_manager.py
+++ b/swebench/harness/context_manager.py
@@ -367,6 +367,7 @@ class TestbedContextManager:
         self.path_conda = os.path.abspath(self.path_conda)
         path_activate = os.path.join(self.path_conda, "bin", "activate")
         exec_cmd = os.path.join(self.path_conda, "bin", "conda")
+        env_list = get_conda_env_names(exec_cmd)
 
         # Set up testbed (environment, github repo) for each repo
         for repo, version_to_setup_ref in self.setup_refs.items():
@@ -396,6 +397,11 @@ class TestbedContextManager:
                 else:
                     self.log.write(f"Repo for {repo_prefix} version {version} exists: {repo_path}; skipping")
 
+                # Skip if conda environment already exists
+                if env_name in env_list:
+                    self.log.write(f"Environment {env_name} already exists; skipping")
+                    continue
+
                 self.create_conda_env(
                     version,
                     path_activate,
@@ -410,93 +416,88 @@ class TestbedContextManager:
     def create_conda_env(
         self, version, path_activate, exec_cmd, version_to_setup_ref, install, env_name
     ):
-        with FileLock(f"/tmp/conda-env-create.lock"):
-            if env_name in get_conda_env_names(exec_cmd):
-                self.log.write(f"Environment {env_name} already exists; skipping")
-                return
+        # Get setup reference instance
+        setup_ref_instance = version_to_setup_ref[version]
 
-            # Get setup reference instance
-            setup_ref_instance = version_to_setup_ref[version]
+        # Create conda environment according to install instructinos
+        pkgs = install["packages"] if "packages" in install else ""
+        if pkgs == "requirements.txt":
+            # Create environment
+            cmd = f"{exec_cmd} create -n {env_name} python={install['python']} -y"
+            self.log.write(f"Creating environment {env_name}")
+            self.exec(cmd.split(" "))
 
-            # Create conda environment according to install instructinos
-            pkgs = install["packages"] if "packages" in install else ""
-            if pkgs == "requirements.txt":
-                # Create environment
-                cmd = f"{exec_cmd} create -n {env_name} python={install['python']} -y"
+            # Install dependencies
+            path_to_reqs = get_requirements(setup_ref_instance, self.testbed)
+            cmd = f". {path_activate} {env_name} && echo 'activate successful' && pip install -r {path_to_reqs}"
+            self.log.write(
+                f"Installing dependencies for {env_name}; Command: {cmd}"
+            )
+            self.exec(["bash", "-c", cmd])
+            os.remove(path_to_reqs)
+        elif pkgs == "environment.yml":
+            if "no_use_env" in install and install["no_use_env"]:
+                # Create environment from yml
+                path_to_reqs = get_environment_yml(
+                    setup_ref_instance, env_name, save_path=self.testbed
+                )
+
+                # `conda create` based installation
+                cmd = f"{exec_cmd} create -c conda-forge -n {env_name} python={install['python']} -y"
                 self.log.write(f"Creating environment {env_name}")
                 self.exec(cmd.split(" "))
 
                 # Install dependencies
-                path_to_reqs = get_requirements(setup_ref_instance, self.testbed)
-                cmd = f". {path_activate} {env_name} && echo 'activate successful' && pip install -r {path_to_reqs}"
+                cmd = f"{exec_cmd} env update -f {path_to_reqs}"
                 self.log.write(
                     f"Installing dependencies for {env_name}; Command: {cmd}"
                 )
-                self.exec(["bash", "-c", cmd])
-                os.remove(path_to_reqs)
-            elif pkgs == "environment.yml":
-                if "no_use_env" in install and install["no_use_env"]:
-                    # Create environment from yml
-                    path_to_reqs = get_environment_yml(
-                        setup_ref_instance, env_name, save_path=self.testbed
-                    )
-
-                    # `conda create` based installation
-                    cmd = f"{exec_cmd} create -c conda-forge -n {env_name} python={install['python']} -y"
-                    self.log.write(f"Creating environment {env_name}")
-                    self.exec(cmd.split(" "))
-
-                    # Install dependencies
-                    cmd = f"{exec_cmd} env update -f {path_to_reqs}"
-                    self.log.write(
-                        f"Installing dependencies for {env_name}; Command: {cmd}"
-                    )
-                    self.exec(cmd.split(" "))
-                else:
-                    # Create environment from yml
-                    path_to_reqs = get_environment_yml(
-                        setup_ref_instance,
-                        env_name,
-                        save_path=self.testbed,
-                        python_version=install["python"],
-                    )
-
-                    # `conda env create` based installation
-                    cmd = f"{exec_cmd} env create --file {path_to_reqs}"
-                    self.log.write(f"Creating environment {env_name}")
-                    self.exec(cmd.split(" "))
-
-                    # Remove environment.yml
-                os.remove(path_to_reqs)
+                self.exec(cmd.split(" "))
             else:
-                # Create environment + install dependencies
-                cmd = f"{exec_cmd} create -n {env_name} python={install['python']} {pkgs} -y"
+                # Create environment from yml
+                path_to_reqs = get_environment_yml(
+                    setup_ref_instance,
+                    env_name,
+                    save_path=self.testbed,
+                    python_version=install["python"],
+                )
+
+                # `conda env create` based installation
+                cmd = f"{exec_cmd} env create --file {path_to_reqs}"
                 self.log.write(f"Creating environment {env_name}")
                 self.exec(cmd.split(" "))
 
-            arch = platform.machine()
-            arch_specific_packages = install.get("arch_specific_packages", {}).get(
-                arch, ""
-            )
-            if arch_specific_packages:
-                cmd = f". {path_activate} {env_name} && conda install {arch_specific_packages} -y"
-                self.log.write(
-                    f"Installing arch-specific packages for {env_name}; Command: {cmd}"
-                )
-                self.exec(["bash", "-c", cmd])
+                # Remove environment.yml
+            os.remove(path_to_reqs)
+        else:
+            # Create environment + install dependencies
+            cmd = f"{exec_cmd} create -n {env_name} python={install['python']} {pkgs} -y"
+            self.log.write(f"Creating environment {env_name}")
+            self.exec(cmd.split(" "))
 
-            # All conda environments should have flake8 installed
-            if "pip_packages" not in install:
-                install["pip_packages"] = []
-            install["pip_packages"].append("flake8")
-
-            # Install additional packages
-            pip_packages = " ".join(install["pip_packages"])
-            cmd = f". {path_activate} {env_name} && pip install {pip_packages}"
+        arch = platform.machine()
+        arch_specific_packages = install.get("arch_specific_packages", {}).get(
+            arch, ""
+        )
+        if arch_specific_packages:
+            cmd = f". {path_activate} {env_name} && conda install {arch_specific_packages} -y"
             self.log.write(
-                f"Installing pip packages for {env_name}; Command: {cmd}"
+                f"Installing arch-specific packages for {env_name}; Command: {cmd}"
             )
             self.exec(["bash", "-c", cmd])
+
+        # All conda environments should have flake8 installed
+        if "pip_packages" not in install:
+            install["pip_packages"] = []
+        install["pip_packages"].append("flake8")
+
+        # Install additional packages
+        pip_packages = " ".join(install["pip_packages"])
+        cmd = f". {path_activate} {env_name} && pip install {pip_packages}"
+        self.log.write(
+            f"Installing pip packages for {env_name}; Command: {cmd}"
+        )
+        self.exec(["bash", "-c", cmd])
 
     def get_distributed_tasks(self) -> list:
         """

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -156,11 +156,11 @@ def get_requirements(instance: dict, save_path: str = None):
     for req_path in MAP_REPO_TO_REQS_PATHS.get(instance["repo"], []):
         reqs_url = os.path.join(SWE_BENCH_URL_RAW, instance["repo"], instance[commit], req_path)
         reqs = requests.get(reqs_url)
-        if reqs.status_code != 200:
+        if reqs.status_code == 200:
+            lines = reqs.text.split("\n")
+            all_req_lines.extend(lines)
+        else:
             print(f"Could not find requirements.txt at paths {MAP_REPO_TO_REQS_PATHS[instance['repo']]}")
-            return None
-        lines = reqs.text.split("\n")
-        all_req_lines.extend(lines)
 
     original_req = []
     additional_reqs = []


### PR DESCRIPTION
`TestbedContextManager` doesn't look like it's meant to be run more than once. Now we'll run it once at the start and use it to distribute testbed environments to workers. This means each worker operates on a unique repositories and version pairs. This change also contains a few bug fixes (introduced by us), necessary to run cleanly.