### PR TITLE
feat: Include search context in generate step

### DIFF
--- a/appmap/solve/solver.py
+++ b/appmap/solve/solver.py
@@ -63,6 +63,7 @@ class Solver:
         self.plan_file = os.path.join(self.work_dir, "plan.md")
         self.solution_file = os.path.join(self.work_dir, "solution.md")
         self.apply_file = os.path.join(self.work_dir, "apply.md")
+        self.context_file = os.path.join(self.work_dir, "search_context.json")
         self.files = []
         self.files_changed = []
         self.test_succeeded_files = None
@@ -114,6 +115,7 @@ class Solver:
             self.instance_id,
             self.appmap_command,
             self.plan_file,
+            self.context_file,
         )
 
     def list_files(self):
@@ -137,6 +139,7 @@ class Solver:
             self.plan_file,
             self.solution_file,
             self.files,
+            self.context_file,
         )
 
     def apply_changes(self):

--- a/appmap/solve/steps/step_plan.py
+++ b/appmap/solve/steps/step_plan.py
@@ -7,8 +7,21 @@ import re
 
 
 def step_plan(
-    log_dir, args, issue_file, work_dir, instance_id, appmap_command, plan_file
+    log_dir, args, issue_file, work_dir, instance_id, appmap_command, plan_file, context_file
 ):
+    print(f"[plan] ({instance_id}) Searching for context using {args.issue_file}")
+    context_prompt = os.path.join(work_dir, "search_context.txt")
+    with open(context_prompt, "w") as apply_f:
+        apply_f.write("@context /nofence /format=json\n")
+    run_navie_command(
+        log_dir,
+        command=appmap_command,
+        context_path=issue_file,
+        input_path=context_prompt,
+        output_path=context_file,
+        log_path=os.path.join(work_dir, "search_context.log"),
+    )
+
     print(f"[plan] ({instance_id}) Generating a plan for {args.issue_file}")
 
     plan_prompt = os.path.join(work_dir, "plan.txt")


### PR DESCRIPTION
- Performs an additional context search during the plan step and writes it to a JSON file
- The generate step now uses this context, after filtering out files included in full text