### PR TITLE
Revert "fix: run django 3.1, 3.2 with python 3.8"

### DIFF
--- a/swebench/harness/constants.py
+++ b/swebench/harness/constants.py
@@ -115,7 +115,7 @@ MAP_VERSION_TO_INSTALL_DJANGO.update(
             "packages": "requirements.txt",
             "install": "python -m pip install -e .",
         }
-        for k in ["3.0"]
+        for k in ["3.0", "3.1", "3.2"]
     }
 )
 MAP_VERSION_TO_INSTALL_DJANGO.update(
@@ -126,7 +126,7 @@ MAP_VERSION_TO_INSTALL_DJANGO.update(
             "packages": "requirements.txt",
             "install": "python -m pip install -e .",
         }
-        for k in ["3.1", "3.2", "4.0"]
+        for k in ["4.0"]
     }
 )
 MAP_VERSION_TO_INSTALL_DJANGO.update(


### PR DESCRIPTION
This reverts commit 1165b2def1a331833cdd421c26b0eb375ac781c9.

This commit changes the output of test runs in Django, causing eval to fail to match the expected output. This will cause the reporter to report a successful patch as failed.