### PR TITLE
Revert to tar.xzing the partial results

### DIFF
--- a/.github/workflows/solve.yml
+++ b/.github/workflows/solve.yml
@@ -223,14 +223,17 @@ jobs:
             --num_processes 8 \
             --path_conda $(conda info --base)
 
+      - name: Compress evaluation results
+        if: ${{ always() }}
+        run: |
+          tar -cJf output_${{ matrix.index }}.tar.xz logs predictions.jsonl
+
       - name: Upload evaluation results
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: output_${{ matrix.index }}
-          path: |
-            logs
-            predictions.jsonl
+          path: output_${{ matrix.index }}.tar.xz
 
   report:
     needs:
@@ -246,12 +249,12 @@ jobs:
         with:
           path: ./eval-results
 
-      - name: Merge evaluation results
+      - name: Unpack evaluation results
         run: |
           mkdir -p logs
-          for dir in eval-results/*; do
-            cat $dir/predictions.jsonl >> predictions.jsonl
-            mv $dir/logs/* logs
+          for file in eval-results/**/*.tar.xz; do
+            tar --to-stdout -xJf "$file" predictions.jsonl >> predictions.jsonl
+            tar -xJf "$file" logs
           done
 
       # Cache the conda environment


### PR DESCRIPTION
It would be more elegant to upgrade to artifacts v4 and rely on it zipping, but I got frustrated trying to make it work.

I did fix a couple bugs, so there's that:
- crash at the end of the benchmark,
- too many inputs (removed the num_workers altogether, it defaults to cpu count: https://github.com/getappmap/SWE-bench/blob/a4bca918bc5a10cb2ff39329153b338d17e12d83/appmap/solve.py#L363 )