### PR TITLE
ci: Bump artifact actions to v4

### DIFF
--- a/.github/workflows/solve.yml
+++ b/.github/workflows/solve.yml
@@ -228,11 +228,12 @@ jobs:
           tar -cJf output_${{ matrix.index }}.tar.xz logs predictions.jsonl
 
       - name: Upload evaluation results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: output_${{ matrix.index }}
           path: output_${{ matrix.index }}.tar.xz
+          compression-level: 0
 
   report:
     needs:
@@ -244,7 +245,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download evaluation results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./eval-results
 


### PR DESCRIPTION
This shouldn't change anything about the run, but it will squash a deprecation warning and make the artifacts show up as soon as they're uploaded.