### PR TITLE
fix: Be more robust in face of failure to unpack AppMap archives

### DIFF
--- a/appmap/solve.py
+++ b/appmap/solve.py
@@ -365,9 +365,16 @@ def extract_appmaps(instance, testbed):
         instance["repo"].split("/")[-1] + "-" + instance["version"]
     )
     if appmap_archive is not None:
-        print(f"AppMap archive: {appmap_archive}", flush=True)
-        appmap_archive.extract(testbed)
-        return appmap_archive.name
+        try:
+            print(f"AppMap archive: {appmap_archive}", flush=True)
+            appmap_archive.extract(testbed)
+            return appmap_archive.name
+        except:
+            print("Error extracting AppMaps; continuing without", flush=True)
+            import traceback
+
+            traceback.print_exc()
+            return None
 
 
 def split_runner_instances(


### PR DESCRIPTION
- Check existence of appmap.yml instead of the whole directory.
- On failure, print the error and return appmap_archive=None instead of bailing.