### PR TITLE
fix: Only omit specific files when generating patches

### DIFF
--- a/appmap/solve/patch.py
+++ b/appmap/solve/patch.py
@@ -1,0 +1,19 @@
+from unidiff import PatchSet
+
+
+def exclude_files(diff: str, paths: list[str]) -> str:
+    """
+    Modify a patch to exclude certain files.
+    """
+    result = PatchSet("")
+    result.extend([p for p in PatchSet(diff) if p.path not in paths])
+    return str(result)
+
+
+# these files are modified by SWE-bench environment setup
+# in sphinx, and the solver has no business touching them anyway
+EXCLUDED = ["setup.py", "tox.ini"]
+
+
+def clean_patch(diff: str) -> str:
+    return exclude_files(diff, EXCLUDED)

--- a/appmap/solve/solver.py
+++ b/appmap/solve/solver.py
@@ -7,6 +7,7 @@ import sys
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(SCRIPT_DIR, "..", ".."))
 
+from appmap.solve.patch import clean_patch
 from appmap.solve.run_command import run_command
 from appmap.solve.is_test_file import is_test_file
 
@@ -276,9 +277,10 @@ class Solver:
 
         print(f"[solver] ({self.instance_id}) Files changed: {self.files_changed}")
 
-        diff_command = f"git diff -- {' '.join(self.files_changed)}"
+        diff_command = f"git diff"
         diff = run_command(self.log_dir, diff_command, fail_on_error=True)
         if diff:
+            diff = clean_patch(diff)
             diff_file = os.path.join(self.work_dir, f"{result_name}.patch")
             with open(diff_file, "w") as f:
                 f.write(diff)

--- a/appmap/solve/steps/step_posttest.py
+++ b/appmap/solve/steps/step_posttest.py
@@ -4,6 +4,7 @@ import subprocess
 from swebench.harness.constants import MAP_REPO_TO_TEST_FRAMEWORK
 
 from ..format_instructions import format_instructions
+from ..patch import clean_patch
 from ..run_navie_command import run_navie_command
 from ..run_command import run_command
 
@@ -34,7 +35,9 @@ def step_posttest(
 
     # Run the diff command
     diff_command = f"git diff"
-    file_diff = run_command(posttest_log_dir, diff_command, fail_on_error=True)
+    file_diff = clean_patch(
+        run_command(posttest_log_dir, diff_command, fail_on_error=True)
+    )
     print(f"[posttest] ({instance_id}) Current project diff:")
     print(file_diff)
     diff_file = os.path.join(posttest_log_dir, "solve.patch")
@@ -189,7 +192,9 @@ only present in the file/content to help you identify which line has the lint er
 
     print(f"[posttest] ({instance_id}) Changes applied:")
 
-    file_diff = run_command(posttest_log_dir, diff_command, fail_on_error=True)
+    file_diff = clean_patch(
+        run_command(posttest_log_dir, diff_command, fail_on_error=True)
+    )
     print(file_diff)
     repair_diff_file = os.path.join(posttest_log_dir, "solve_repair.patch")
     with open(repair_diff_file, "w") as f:

--- a/environment.yml
+++ b/environment.yml
@@ -20,4 +20,5 @@ dependencies:
     - sentencepiece
     - protobuf
     - pygithub
+    - unidiff
   - conda-forge::gh

--- a/test/appmap/test_erase_test_changes.py
+++ b/test/appmap/test_erase_test_changes.py
@@ -4,10 +4,11 @@ import pytest
 import os
 
 # Add the parent directory to the Python path
-thisdir = Path( os.path.dirname(os.path.abspath(__file__)) )
+thisdir = Path(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(thisdir.parent.parent.as_posix())
 
 from appmap.solve.steps.erase_test_changes import erase_test_changes
+
 
 @pytest.fixture
 def change_data_with_test():
@@ -32,6 +33,7 @@ def change_data_with_test():
     </change>
     """
 
+
 @pytest.fixture
 def change_data_without_test(tmpdir):
     return """
@@ -55,6 +57,7 @@ def change_data_without_test(tmpdir):
     </change>
     """
 
+
 @pytest.fixture
 def change_data_with_no_changes():
     return """
@@ -67,7 +70,8 @@ def change_data_with_no_changes():
             modified_content_1
         </xmodified>
     </xchange>
-    """    
+    """
+
 
 @pytest.fixture
 def change_data_with_no_file():
@@ -81,7 +85,8 @@ def change_data_with_no_file():
             modified_content_1
         </xmodified>
     </change>
-    """    
+    """
+
 
 def test_erase_test_changes_with_test(change_data_with_test):
     content = erase_test_changes("test_instance", change_data_with_test)
@@ -89,18 +94,21 @@ def test_erase_test_changes_with_test(change_data_with_test):
     assert "<file>tests/test_file.py<" not in content
     assert "<file>src/main.py<" in content
 
+
 def test_erase_test_changes_without_test(change_data_without_test):
     content = erase_test_changes("test_instance", change_data_without_test)
 
     assert "<file>src/main.py<" in content
     assert "<file>src/utils.py<" in content
 
+
 def test_erase_test_data_with_no_changes(change_data_with_no_changes):
     content = erase_test_changes("test_instance", change_data_with_no_changes)
 
     assert change_data_with_no_changes == content
 
+
 def test_erase_test_data_with_no_file(change_data_with_no_file):
     content = erase_test_changes("test_instance", change_data_with_no_file)
 
-    assert change_data_with_no_file == content    
+    assert change_data_with_no_file == content

--- a/test/appmap/test_is_test_file.py
+++ b/test/appmap/test_is_test_file.py
@@ -1,37 +1,36 @@
 from pathlib import Path
 import sys
-import pytest
 import os
 
 # Add the parent directory to the Python path
-thisdir = Path( os.path.dirname(os.path.abspath(__file__)) )
+thisdir = Path(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(thisdir.parent.parent.as_posix())
 
 from appmap.solve.is_test_file import is_test_file
 
+
 def test_is_test_file():
-  assert is_test_file("test/test_file.py")
-  assert is_test_file("tests/test_file.py")
-  assert is_test_file("testing/test_file.py")
-  assert is_test_file("tests/admin_inlines/tests.py")
-  assert is_test_file("test_file_test.py")
-  assert is_test_file("test_file.py")
-  assert is_test_file("testcases/test_file.py")
-  assert is_test_file("test/test_file.py")
-  assert is_test_file("src/test_file.py")
-  assert is_test_file("src/test_file_test.py")
-  assert is_test_file("src/tests/test_file.py")
-  assert is_test_file("src/testing/test_file.py")
-  assert is_test_file("src/testcases/test_file.py")
-  assert is_test_file("testcases/mymodule.py")
+    assert is_test_file("test/test_file.py")
+    assert is_test_file("tests/test_file.py")
+    assert is_test_file("testing/test_file.py")
+    assert is_test_file("tests/admin_inlines/tests.py")
+    assert is_test_file("test_file_test.py")
+    assert is_test_file("test_file.py")
+    assert is_test_file("testcases/test_file.py")
+    assert is_test_file("test/test_file.py")
+    assert is_test_file("src/test_file.py")
+    assert is_test_file("src/test_file_test.py")
+    assert is_test_file("src/tests/test_file.py")
+    assert is_test_file("src/testing/test_file.py")
+    assert is_test_file("src/testcases/test_file.py")
+    assert is_test_file("testcases/mymodule.py")
 
 
 def test_is_not_test_file():
-  assert not is_test_file("src/main.py")
-  assert not is_test_file("src/utils.py")
-  assert not is_test_file("src/test.py")
-  assert not is_test_file("src/_pytest.py")
-  assert not is_test_file("src/_pytest/skipping.py")
-  assert not is_test_file("_pytest/skipping_test.py")
-  assert not is_test_file("src/_pytest/pathlib.py")
-
+    assert not is_test_file("src/main.py")
+    assert not is_test_file("src/utils.py")
+    assert not is_test_file("src/test.py")
+    assert not is_test_file("src/_pytest.py")
+    assert not is_test_file("src/_pytest/skipping.py")
+    assert not is_test_file("_pytest/skipping_test.py")
+    assert not is_test_file("src/_pytest/pathlib.py")

--- a/test/appmap/test_patch.py
+++ b/test/appmap/test_patch.py
@@ -1,0 +1,155 @@
+from pathlib import Path
+import sys
+import os
+
+# Add the parent directory to the Python path
+thisdir = Path(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(thisdir.parent.parent.as_posix())
+
+from appmap.solve.patch import clean_patch
+
+SETUP_PATCH = """diff --git a/setup.py b/setup.py
+index c0a9c2b0d..579fdee60 100644
+--- a/setup.py
++++ b/setup.py
+@@ -15,21 +15,21 @@ if sys.version_info < (3, 6):
+     sys.exit(1)
+ 
+ install_requires = [
+-    'sphinxcontrib-applehelp',
+-    'sphinxcontrib-devhelp',
++    'sphinxcontrib-applehelp<=1.0.7',
++    'sphinxcontrib-devhelp<=1.0.5',
+     'sphinxcontrib-jsmath',
+-    'sphinxcontrib-htmlhelp>=2.0.0',
+-    'sphinxcontrib-serializinghtml>=1.1.5',
+-    'sphinxcontrib-qthelp',
+-    'Jinja2>=2.3',
++    'sphinxcontrib-htmlhelp>=2.0.0,<=2.0.4',
++    'sphinxcontrib-serializinghtml>=1.1.5,<=1.1.9',
++    'sphinxcontrib-qthelp<=1.0.6',
++    'Jinja2<3.0',
+     'Pygments>=2.0',
+     'docutils>=0.14,<0.18',
+     'snowballstemmer>=1.1',
+     'babel>=1.3',
+-    'alabaster>=0.7,<0.8',
++    'alabaster>=0.7,<0.7.12',
+     'imagesize',
+     'requests>=2.5.0',
+-    'packaging',
++    'packaging', 'markupsafe<=2.0.1',
+     "importlib-metadata>=4.4; python_version < '3.10'",
+ ]
+ 
+"""
+
+TYPEHINTS_PATCH = """diff --git a/sphinx/ext/autodoc/typehints.py b/sphinx/ext/autodoc/typehints.py
+index f4b4dd35e..4a9f6af74 100644
+--- a/sphinx/ext/autodoc/typehints.py
++++ b/sphinx/ext/autodoc/typehints.py
+@@ -17,7 +17,9 @@ from docutils.nodes import Element
+ 
+ from sphinx import addnodes
+ from sphinx.application import Sphinx
+-from sphinx.util import inspect, typing
++from sphinx.util import inspect, typing, logging
++
++logger = logging.getLogger(__name__)
+ 
+ 
+ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
+@@ -30,9 +32,9 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
+             sig = inspect.signature(obj, type_aliases=app.config.autodoc_type_aliases)
+             for param in sig.parameters.values():
+                 if param.annotation is not param.empty:
+-                    annotation[param.name] = typing.stringify(param.annotation)
++                    annotation[param.name] = typing.stringify(param.annotation, short=app.config.autodoc_unqualified_typehints)
+             if sig.return_annotation is not sig.empty:
+-                annotation['return'] = typing.stringify(sig.return_annotation)
++                annotation['return'] = typing.stringify(sig.return_annotation, short=app.config.autodoc_unqualified_typehints)
+     except (TypeError, ValueError):
+         pass
+ 
+@@ -155,10 +157,13 @@ def augment_descriptions_with_types(
+             has_type.add('return')
+ 
+     # Add 'type' for parameters with a description but no declared type.
+-    for name in annotations:
++    for name, annotation in annotations.items():
+         if name in ('return', 'returns'):
+             continue
+         if name in has_description and name not in has_type:
++            # Use short form if autodoc_unqualified_typehints is enabled
++            if app.config.autodoc_unqualified_typehints:
++                annotation = typing.stringify(annotation, short=True)
+             field = nodes.field()
+             field += nodes.field_name('', 'type ' + name)
+             field += nodes.field_body('', nodes.paragraph('', annotations[name]))
+"""
+
+TOX_PATCH = """diff --git a/tox.ini b/tox.ini
+index c006fa5a6..e51fa8598 100644
+--- a/tox.ini
++++ b/tox.ini
+@@ -28,7 +28,7 @@ setenv =
+     PYTHONWARNINGS = all,ignore::ImportWarning:importlib._bootstrap_external,ignore::DeprecationWarning:site,ignore::DeprecationWarning:distutils,ignore::DeprecationWarning:pip._vendor.packaging.version
+     PYTEST_ADDOPTS = {env:PYTEST_ADDOPTS:} --color yes
+ commands=
+-    python -X dev -m pytest --durations 25 {posargs}
++    python -X dev -m pytest -rA --durations 25 {posargs}
+ 
+ [testenv:du-latest]
+ commands =
+"""
+
+NDIM_ARRAY_PATCH = """diff --git a/sympy/tensor/array/ndim_array.py b/sympy/tensor/array/ndim_array.py
+index 6490a655a4..5b88a15a24 100644
+--- a/sympy/tensor/array/ndim_array.py
++++ b/sympy/tensor/array/ndim_array.py
+@@ -194,6 +194,9 @@ def f(pointer):
+             if not isinstance(pointer, Iterable):
+                 return [pointer], ()
+ 
++            if not pointer:  # Detect empty iterable
++                return [], ()
++
+             result = []
+             elems, shapes = zip(*[f(i) for i in pointer])
+             if len(set(shapes)) != 1:
+@@ -210,7 +213,7 @@ def _handle_ndarray_creation_inputs(cls, iterable=None, shape=None, **kwargs):
+         from sympy.tensor.array import SparseNDimArray
+ 
+         if shape is None:
+-            if iterable is None:
++            if iterable is None or (isinstance(iterable, Iterable) and not iterable):
+                 shape = ()
+                 iterable = ()
+             # Construction of a sparse array from a sparse array
+"""
+
+
+def test_clean_from_end():
+    patch = "\n".join([TYPEHINTS_PATCH, TOX_PATCH])
+    # Requires a slight fixup, but I guess it's OK
+    assert clean_patch(patch) == "\n".join([TYPEHINTS_PATCH, ""])
+
+
+def test_clean_from_middle():
+    patch = "\n".join([TYPEHINTS_PATCH, TOX_PATCH, NDIM_ARRAY_PATCH])
+    assert clean_patch(patch) == "\n".join([TYPEHINTS_PATCH, NDIM_ARRAY_PATCH])
+
+
+def test_clean_multiple():
+    patch = "\n".join([TYPEHINTS_PATCH, SETUP_PATCH, TOX_PATCH, NDIM_ARRAY_PATCH])
+    assert clean_patch(patch) == "\n".join([TYPEHINTS_PATCH, NDIM_ARRAY_PATCH])
+
+
+def test_clean_from_start():
+    patch = "\n".join([TOX_PATCH, TYPEHINTS_PATCH])
+    assert clean_patch(patch) == TYPEHINTS_PATCH
+
+
+def test_clean_nop():
+    patch = "\n".join([TYPEHINTS_PATCH, NDIM_ARRAY_PATCH])
+    assert clean_patch(patch) == "\n".join([TYPEHINTS_PATCH, NDIM_ARRAY_PATCH])


### PR DESCRIPTION
Including only files originally changed risked throwing away posttest fixes. Instead just filter out tox.ini and setup.py.